### PR TITLE
getCompressedLogs should be getCompressed?

### DIFF
--- a/src/Services/LogKeeperService.php
+++ b/src/Services/LogKeeperService.php
@@ -124,7 +124,7 @@ class LogKeeperService
             }
         }
 
-        $compressedlogs = $this->localRepo->getCompressedLogs();
+        $compressedlogs = $this->localRepo->getCompressed();
 
         foreach ($compressedlogs as $compressedlog) {
 


### PR DESCRIPTION
I appreciate the changes you've made to this very useful package

When I tried to run it I would run into an error "getCompressedLogs" does not exist

That function is only available in the LogUtil class, and I think this was just a typo?

After changing it to getCompressed then all seems to work normal